### PR TITLE
feat: add monte carlo simulation and scenario tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ import numpy as np
 import re
 import matplotlib.pyplot as plt
 import gradio as gr
+from fpdf import FPDF
+from tempfile import NamedTemporaryFile
 
 
 def _to_number(x):
@@ -137,6 +139,91 @@ def plot_kpi(ratios_df, kpi='ROA'):
     return fig
 
 
+def run_monte_carlo(params, n_iter):
+    """Simula KPIs usando distribución normal con media y desviación."""
+    results = {}
+    for kpi, dist in params.items():
+        mean = dist.get('mean', 0)
+        std = max(dist.get('std', 0), 0)
+        sims = np.random.normal(mean, std, int(n_iter))
+        results[kpi] = sims
+    return pd.DataFrame(results)
+
+
+def run_deterministic(params):
+    """Escenarios determinísticos: pesimista, base y optimista."""
+    rows = []
+    for kpi, dist in params.items():
+        mean = dist.get('mean', 0)
+        std = dist.get('std', 0)
+        rows.append(
+            {
+                'KPI': kpi,
+                'Pesimista': mean - std,
+                'Base': mean,
+                'Optimista': mean + std,
+            }
+        )
+    if not rows:
+        return pd.DataFrame(columns=['Pesimista', 'Base', 'Optimista'])
+    return pd.DataFrame(rows).set_index('KPI')
+
+
+def plot_histograms(df):
+    fig, axes = plt.subplots(len(df.columns), 1, figsize=(6, 4 * len(df.columns)))
+    if len(df.columns) == 1:
+        axes = [axes]
+    for ax, col in zip(axes, df.columns):
+        ax.hist(df[col], bins=30, alpha=0.7)
+        ax.set_title(col)
+        ax.set_xlabel('Valor')
+        ax.set_ylabel('Frecuencia')
+    fig.tight_layout()
+    return fig
+
+
+def run_simulation(param_rows, n_iter):
+    params = {}
+    for row in param_rows:
+        if not row or not row[0]:
+            continue
+        kpi, mean, std = row[0], row[1], row[2]
+        params[kpi] = {'mean': float(mean), 'std': float(std)}
+    sims_df = run_monte_carlo(params, int(n_iter))
+    percentiles_df = sims_df.quantile([0.05, 0.5, 0.95]).T
+    percentiles_df.columns = ['p5', 'p50', 'p95']
+    fig = plot_histograms(sims_df)
+    deterministic_df = run_deterministic(params)
+    return percentiles_df, fig, deterministic_df, sims_df, percentiles_df
+
+
+def export_simulation_excel(sims_df):
+    if sims_df is None or sims_df.empty:
+        raise ValueError('No hay resultados para exportar')
+    tmp = NamedTemporaryFile(delete=False, suffix='.xlsx')
+    sims_df.to_excel(tmp.name, index=False)
+    return tmp.name
+
+
+def export_simulation_pdf(percentiles_df):
+    if percentiles_df is None or percentiles_df.empty:
+        raise ValueError('No hay resultados para exportar')
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font('Arial', size=12)
+    pdf.cell(0, 10, 'Resumen percentiles', ln=True)
+    for kpi, row in percentiles_df.iterrows():
+        pdf.cell(
+            0,
+            10,
+            f"{kpi}: P5={row['p5']:.2f} P50={row['p50']:.2f} P95={row['p95']:.2f}",
+            ln=True,
+        )
+    tmp = NamedTemporaryFile(delete=False, suffix='.pdf')
+    pdf.output(tmp.name)
+    return tmp.name
+
+
 def process_files(files, names_text):
     names = [n.strip() for n in names_text.split(',') if n.strip()]
     if len(files) != len(names):
@@ -147,20 +234,44 @@ def process_files(files, names_text):
     ratios_df = compute_ratios(data_dict)
     fig = plot_kpi(ratios_df, 'ROA')
     return ratios_df.reset_index(), fig
+    
 
+with gr.Blocks(title='Dashboard financiero multicompañía') as demo:
+    with gr.Tab('Ratios'):
+        file_input = gr.File(label='Estados financieros', file_count='multiple')
+        names_input = gr.Textbox(label='Nombres de empresas (orden, separados por coma)')
+        run_btn = gr.Button('Procesar')
+        ratios_out = gr.Dataframe(label='Ratios comparativos')
+        plot_out = gr.Plot(label='ROA comparativo')
+        run_btn.click(process_files, inputs=[file_input, names_input], outputs=[ratios_out, plot_out])
 
-demo = gr.Interface(
-    fn=process_files,
-    inputs=[
-        gr.File(label='Estados financieros', file_count='multiple'),
-        gr.Textbox(label='Nombres de empresas (orden, separados por coma)'),
-    ],
-    outputs=[
-        gr.Dataframe(label='Ratios comparativos'),
-        gr.Plot(label='ROA comparativo'),
-    ],
-    title='Dashboard financiero multicompañía',
-)
+    with gr.Tab('Simulación'):
+        params_df = gr.Dataframe(
+            headers=['kpi', 'mean', 'std'],
+            datatype=['str', 'number', 'number'],
+            row_count=3,
+            col_count=3,
+            label='Parámetros',
+        )
+        n_iter_input = gr.Number(value=1000, label='Iteraciones')
+        sim_btn = gr.Button('Simular')
+        percentiles_out = gr.Dataframe(label='Percentiles (P5, P50, P95)')
+        hist_out = gr.Plot(label='Histogramas')
+        deterministic_out = gr.Dataframe(label='Escenarios determinísticos')
+        sims_state = gr.State()
+        perc_state = gr.State()
+        sim_btn.click(
+            run_simulation,
+            inputs=[params_df, n_iter_input],
+            outputs=[percentiles_out, hist_out, deterministic_out, sims_state, perc_state],
+        )
+        export_excel_btn = gr.Button('Exportar Excel')
+        export_pdf_btn = gr.Button('Resumen PDF')
+        excel_file = gr.File(label='Simulación Excel')
+        pdf_file = gr.File(label='Resumen PDF')
+        export_excel_btn.click(export_simulation_excel, inputs=sims_state, outputs=excel_file)
+        export_pdf_btn.click(export_simulation_pdf, inputs=perc_state, outputs=pdf_file)
+
 
 if __name__ == '__main__':
     demo.launch()


### PR DESCRIPTION
## Summary
- add Monte Carlo and deterministic scenario simulators
- expose simulation configuration in new Gradio tab with histogram/percentile views
- allow exporting simulation results to Excel or PDF

## Testing
- `python -m py_compile app.py`
- `pip install pandas numpy matplotlib gradio fpdf` (failed: Could not find a version that satisfies the requirement pandas)


------
https://chatgpt.com/codex/tasks/task_e_689b58354178832e9d1e14fd38b10bb8